### PR TITLE
feat(timetable): implement a builtin lessons parser

### DIFF
--- a/examples/lessons.ts
+++ b/examples/lessons.ts
@@ -1,4 +1,4 @@
-import { authenticatePronoteCredentials, PronoteApiAccountId } from "../src";
+import { authenticatePronoteCredentials, PronoteApiAccountId, TimetableActivity, TimetableLesson } from "../src";
 
 (async () => {
   const pronote = await authenticatePronoteCredentials("https://pronote-vm.dev/pronote", {
@@ -10,24 +10,42 @@ import { authenticatePronoteCredentials, PronoteApiAccountId } from "../src";
     deviceUUID: "my-device-uuid"
   });
 
-  const from = new Date("2024-04-17");
-  // const to = new Date("2023-09-20");
+  const overview = await pronote.getTimetableOverview(new Date("2024-04-15"));
+  const lessons = overview.parseLessons({
+    withSuperposedCanceledLessons: false,
+    withCanceledLessons: true,
+    withPlannedLessons: true
+  });
 
-  const lessons = await pronote.getLessonsForInterval(from);
-  lessons.forEach((lesson) => {
-    // Let's use "???" as a placeholder when there's no subject on a lesson.
-    const subjectName = lesson.subject?.name ?? "???";
-
-
-    console.log(subjectName, "starts the", lesson.start.toLocaleString(), "and ends the", lesson.end.toLocaleString());
-    console.info("(teachers) =>", lesson.teacherNames.join(", ") || "none");
-    console.info("(classrooms) =>", lesson.classrooms.join(", ") || "none");
-    console.info("(groups) =>", lesson.groupNames.join(", ") || "none");
-    console.info("(personal) =>", lesson.personalNames.join(", ") || "none");
-
-    if (lesson.haveLessonResource) {
-      console.log("(info) => has lesson resource/content");
+  lessons.forEach((item) => {
+    if (item instanceof TimetableActivity) {
+      console.log(item.title, "starts the", item.startDate.toLocaleString(), "ends the", item.endDate.toLocaleString());
+      console.log("(attendants) =>", item.attendants.join(", ") || "none");
+      console.log(`(resourceType->${item.resourceTypeName}) => ${item.resourceValue}`);
     }
+    else if (item instanceof TimetableLesson) {
+      // Let's use "???" as a placeholder when there's no subject on a lesson.
+      const subjectName = item.subject?.name ?? "???";
+      console.log(subjectName, "starts the", item.startDate.toLocaleString(), "ends the", item.endDate.toLocaleString());
+
+      console.log("(teachers) =>", item.teacherNames.join(", ") || "none");
+      console.log("(classrooms) =>", item.classrooms.join(", ") || "none");
+      console.log("(groups) =>", item.groupNames.join(", ") || "none");
+      console.log("(personal) =>", item.personalNames.join(", ") || "none");
+
+      if (item.lessonResourceID) {
+        console.log("(info) => has lesson resource/content");
+      }
+
+      if (item.status) {
+        console.log("(status) =>", item.status);
+      }
+
+      console.log("(detention) =>", item.detention);
+      console.log("(exempted) =>", item.exempted);
+    }
+
+    console.info("(notes) =>", item.notes || "none");
 
     // Break line.
     console.log();

--- a/examples/queue-showcase.ts
+++ b/examples/queue-showcase.ts
@@ -24,7 +24,7 @@ import { authenticatePronoteCredentials, PronoteApiAccountId } from "../src";
 
   // Get the timetable for the 4 first weeks.
   const timetables = await Promise.all(
-    [1, 2, 3, 4].map((weekNumber) => pronote.getTimetableForWeek(weekNumber))
+    [1, 2, 3, 4].map((weekNumber) => pronote.getHomeworkForWeek(weekNumber))
   );
 
   const amountOfLessons = timetables.map((timetable) => timetable.length);

--- a/src/api/user/timetable/index.ts
+++ b/src/api/user/timetable/index.ts
@@ -6,13 +6,11 @@ import { createPronoteAPICall } from "~/pronote/requestAPI";
 import { makeApiHandler } from "~/utils/api";
 
 export const callApiUserTimetable = makeApiHandler<ApiUserTimetable>(async (fetcher, input) => {
-  if (input.weekNumber <= 0) {
-    throw new Error(`Invalid input on callApiUserTimetable, "weekNumber" should be a strictly positive number, got ${input.weekNumber}`);
-  }
-
   const request_payload = input.session.writePronoteFunctionPayload<PronoteApiUserTimetable["request"]>({
     donnees: {
+      estEDTAnnuel: false,
       estEDTPermanence: false,
+
       avecAbsencesEleve: false,
       avecRessourcesLibrePiedHoraire: false,
 
@@ -21,9 +19,29 @@ export const callApiUserTimetable = makeApiHandler<ApiUserTimetable>(async (fetc
       avecConseilDeClasse: true,
       avecCoursSortiePeda: true,
       avecDisponibilites: true,
+      avecRetenuesEleve: true,
 
-      NumeroSemaine: input.weekNumber,
-      numeroSemaine: input.weekNumber,
+      edt: { G: 16, L: "Emploi du temps" },
+
+      DateDebut: {
+        _T: 7,
+        V: input.startPronoteDate
+      },
+      dateDebut: {
+        _T: 7,
+        V: input.startPronoteDate
+      },
+
+      ...(input.endPronoteDate && {
+        DateFin: {
+          _T: 7,
+          V: input.endPronoteDate
+        },
+        dateFin: {
+          _T: 7,
+          V: input.endPronoteDate
+        }
+      }),
 
       Ressource: input.resource,
       ressource: input.resource

--- a/src/constants/lessonCategory.ts
+++ b/src/constants/lessonCategory.ts
@@ -21,3 +21,11 @@ export enum PronoteApiLessonContentCategory {
   /** Corresponds to "Visio" */
   VISIO = 12
 }
+
+export enum PronoteApiLessonStatusType {
+  EnseignementNormal = 0,
+  ConseilDeClasse = 1,
+  EnseignementRemplacement = 2,
+  EnseignementHistorique = 3,
+  EnseignementSuppleant = 4
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export { PronoteApiGradeType } from "./pronote/grades";
 
 // Exporting constants from Pronote API.
 export { PronoteApiHomeworkDifficulty, PronoteApiHomeworkReturnType } from "~/constants/homework";
-export { PronoteApiLessonContentCategory } from "~/constants/lessonCategory";
+export { PronoteApiLessonContentCategory, PronoteApiLessonStatusType } from "~/constants/lessonCategory";
 export { PronoteApiAttachmentType } from "~/constants/attachments";
 export { PronoteApiNewsQuestionType } from "~/constants/news";
 export { PronoteApiAccountId } from "~/constants/accounts";
@@ -52,6 +52,8 @@ export { StudentHomework } from "~/parser/homework";
 export { StudentTheme } from "~/parser/theme";
 export { StudentGrade } from "~/parser/grade";
 export { Period, OngletPeriod } from "~/parser/period";
+export { TimetableOverview } from "~/parser/timetable";
+export { TimetableActivity, TimetableLesson } from "~/parser/timetableLesson";
 export { StudentNews, StudentNewsCategory, StudentNewsSurvey, StudentNewsInformation, StudentNewsItemQuestion } from "~/parser/news";
 export { StudentAbsence, StudentDelay, StudentPunishment, StudentObservation } from "~/parser/attendance";
 export { StudentDiscussionsOverview, StudentDiscussion, StudentDiscussionFolder } from "~/parser/discussion";

--- a/src/parser/timetable.ts
+++ b/src/parser/timetable.ts
@@ -1,0 +1,185 @@
+import type { PronoteApiUserTimetable } from "~/api/user/timetable/types";
+import type Pronote from "~/client/Pronote";
+
+import { TimetableActivity, TimetableLesson } from "~/parser/timetableLesson";
+import { PronoteApiLessonStatusType } from "~/constants/lessonCategory";
+
+type TimetableOverviewParsingParameters = {
+  withSuperposedCanceledLessons: boolean;
+  withCanceledLessons: boolean;
+  withPlannedLessons: boolean;
+};
+
+type TimetableItem = TimetableActivity | TimetableLesson;
+type TimetableItemWithVisible = (TimetableItem & { __visible__?: boolean });
+
+export class TimetableOverview {
+  readonly #client: Pronote;
+  readonly #lessons: TimetableItem[];
+  // TODO: Add a way to parse this !!!
+  readonly #absences: PronoteApiUserTimetable["response"]["donnees"]["absences"];
+  readonly #withCanceledLessons: boolean;
+
+  constructor (client: Pronote, data: PronoteApiUserTimetable["response"]["donnees"]) {
+    this.#client = client;
+    this.#lessons = data.ListeCours
+      .map((lesson) => {
+        const isActivity = "estSortiePedagogique" in lesson && lesson.estSortiePedagogique;
+        const TimetableItem = isActivity ? TimetableActivity : TimetableLesson;
+        return new TimetableItem(client, lesson);
+      })
+      .sort((a, b) => (
+        a.startDate.getTime() - b.startDate.getTime()
+      ));
+
+    this.#absences = data.absences;
+    this.#withCanceledLessons = data.avecCoursAnnule ?? true; // Default on Pronote is `true` apparently.
+  }
+
+  public parseLessons (parameters: TimetableOverviewParsingParameters = {
+    withSuperposedCanceledLessons: false,
+    withCanceledLessons: this.#withCanceledLessons,
+    withPlannedLessons: true
+  }): Array<TimetableItem> {
+    const lessons = this.#lessons as TimetableItemWithVisible[];
+
+    if (!parameters.withCanceledLessons) {
+      for (const lesson of lessons) {
+        if (lesson instanceof TimetableLesson && lesson.canceled) {
+          lesson.__visible__ = false;
+        }
+      }
+    }
+
+    if (!parameters.withPlannedLessons) {
+      for (const lesson of lessons) {
+        if (
+          lesson instanceof TimetableLesson &&
+          lesson.__visible__ !== false &&
+          !lesson.canceled &&
+          [
+            PronoteApiLessonStatusType.EnseignementNormal,
+            PronoteApiLessonStatusType.EnseignementHistorique,
+            PronoteApiLessonStatusType.EnseignementSuppleant
+          ].indexOf(lesson.genre) >= 0
+        ) {
+          lesson.__visible__ = false;
+        }
+      }
+    }
+
+    if (parameters.withCanceledLessons && !parameters.withSuperposedCanceledLessons) {
+      let foundInvisibleCanceled = this.#makeSuperposedCanceledLessonsInvisible(lessons);
+      while (foundInvisibleCanceled) {
+        foundInvisibleCanceled = this.#makeSuperposedCanceledLessonsInvisible(lessons);
+      }
+    }
+
+    const parsed = lessons.filter((lesson) => lesson.__visible__ !== false);
+
+    // Cleanup the `__visible__` property from the lessons.
+    for (const lesson of lessons) {
+      delete lesson.__visible__;
+    }
+
+    return parsed;
+  }
+
+  #getItemEndBlockPosition (item: TimetableActivity | TimetableLesson): number {
+    const Fin = item.blockPosition + item.blockLength - 1;
+    const PlacesParJour = this.#client.loginInformations.donnees.General.PlacesParJour;
+
+    let lPlace = Fin;
+
+    const lJourDebut = Math.floor(item.blockPosition / PlacesParJour);
+    if (Math.floor(Fin / PlacesParJour) !== lJourDebut) {
+      lPlace = lJourDebut * PlacesParJour + PlacesParJour - 1;
+    }
+
+    return lPlace;
+  }
+
+  #getTableauIndicesCoursSuperposesDeCours(
+    lessons: (TimetableActivity | TimetableLesson)[],
+    lessonIndex: number,
+    aPlaceOccupees: number[]
+  ) {
+    const lCours = lessons[lessonIndex];
+    const lCoursSuperposees = [lessonIndex];
+
+    const lPlaceDebut = lCours.blockPosition;
+    const lPlaceFin = this.#getItemEndBlockPosition(lCours);
+
+    for (let lPlace = lPlaceDebut; lPlace <= lPlaceFin; lPlace++) {
+      const lIndiceCours = aPlaceOccupees[lPlace];
+      if (typeof lIndiceCours !== "undefined") {
+        if (
+          lIndiceCours !== lessonIndex &&
+          !lCoursSuperposees.includes(lIndiceCours)
+        ) {
+          lCoursSuperposees.push(lIndiceCours);
+        }
+      }
+    }
+
+    return lCoursSuperposees;
+  }
+
+  #makeSuperposedCanceledLessonsInvisible (lessons: TimetableItemWithVisible[]): boolean {
+    let lCours: TimetableItemWithVisible;
+    let lCoursSuperpose: TimetableItemWithVisible;
+    let lPlaceOccupees: number[] = [];
+
+    for (let lessonIndex = 0; lessonIndex < lessons.length; lessonIndex++) {
+      lCours = lessons[lessonIndex];
+
+      const lPlaceDebut = lCours.blockPosition;
+      const lPlaceFin = this.#getItemEndBlockPosition(lCours);
+
+      if (lCours.__visible__ !== false) {
+        for (let lPlace = lPlaceDebut; lPlace <= lPlaceFin; lPlace++) {
+          if (typeof lPlaceOccupees[lPlace] === "undefined") {
+            lPlaceOccupees[lPlace] = lessonIndex;
+          }
+          else {
+            const lCoursSuperposees = this.#getTableauIndicesCoursSuperposesDeCours(
+              lessons,
+              lessonIndex,
+              lPlaceOccupees
+            );
+
+            let lAvecCoursAnnule = false;
+            let lAvecCoursNormal = false;
+
+            for (let j = 0; j < lCoursSuperposees.length; j++) {
+              lCoursSuperpose = lessons[lCoursSuperposees[j]];
+
+              if (!lAvecCoursNormal) {
+                lAvecCoursNormal = !(lCoursSuperpose instanceof TimetableLesson && lCoursSuperpose.canceled);
+              }
+
+              if (!lAvecCoursAnnule) {
+                lAvecCoursAnnule = lCoursSuperpose instanceof TimetableLesson && lCoursSuperpose.canceled;
+              }
+            }
+
+            if (lAvecCoursNormal && lAvecCoursAnnule) {
+              for (let j = 0; j < lCoursSuperposees.length; j++) {
+                lCoursSuperpose = lessons[lCoursSuperposees[j]];
+
+                if (lCoursSuperpose && lCoursSuperpose instanceof TimetableLesson && lCoursSuperpose.canceled) {
+                  lCoursSuperpose.__visible__ = false;
+                  return true;
+                }
+              }
+            }
+
+            break;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
- Implement native interval fetching on timetables
- Implement a `TimetableOverview` to wrap and parse better retrieved data
- Add support for activities in timetables (+ separation with lessons)
- Implement a reducer for lessons : `TimetableOverview#parseLessons` method