### PR TITLE
feat(discussions): implement create, save, delete and send for drafts

### DIFF
--- a/examples/discussions/clear-all-draft.ts
+++ b/examples/discussions/clear-all-draft.ts
@@ -1,0 +1,34 @@
+import { authenticatePronoteCredentials, PronoteApiAccountId } from "../../src";
+
+(async () => {
+  const pronote = await authenticatePronoteCredentials("https://pronote-vm.dev/pronote", {
+    accountTypeID: PronoteApiAccountId.Student,
+    username: "lisa.boulanger", // using my VM credentials here because the demo instance doesn't have any messages.
+    password: "12345678",
+
+    // Because this is just an example, don't forget to change this.
+    deviceUUID: "my-device-uuid"
+  });
+
+  // You can do those checks manually, they're also done internally and will throw an error if the account can't do this.
+  if (!pronote.authorizations.canDiscuss) throw new Error("This account can't discuss, review the permissions.");
+  if (!pronote.authorizations.canDiscussWithTeachers) throw new Error("This account can't discuss with teachers, review the permissions.");
+
+  // Get an overview of available discussions.
+  const discussionsOverview = await pronote.getDiscussionsOverview();
+  // Select the first discussion available.
+  const firstDiscussion = discussionsOverview.discussions[0];
+  console.info("Opening discussion:", firstDiscussion.subject);
+  console.log("Containing", firstDiscussion.numberOfDrafts, "draft(s)...");
+  console.log("Containing", firstDiscussion.numberOfMessages - firstDiscussion.numberOfDrafts, "message(s)...");
+
+  // Fetch the messages overview from the discussion.
+  // You need to fetch the overview in order to send a message.
+  const messagesOverview = await firstDiscussion.fetchMessagesOverview();
+
+  for (const draft of messagesOverview.savedDrafts) {
+    await draft.delete();
+    console.log("Draft deleted:", draft.possessionID);
+  }
+})();
+

--- a/examples/discussions/create-draft.ts
+++ b/examples/discussions/create-draft.ts
@@ -1,0 +1,42 @@
+import { authenticatePronoteCredentials, PronoteApiAccountId } from "../../src";
+
+(async () => {
+  const pronote = await authenticatePronoteCredentials("https://pronote-vm.dev/pronote", {
+    accountTypeID: PronoteApiAccountId.Student,
+    username: "lisa.boulanger", // using my VM credentials here because the demo instance doesn't have any messages.
+    password: "12345678",
+
+    // Because this is just an example, don't forget to change this.
+    deviceUUID: "my-device-uuid"
+  });
+
+  // You can do those checks manually, they're also done internally and will throw an error if the account can't do this.
+  if (!pronote.authorizations.canDiscuss) throw new Error("This account can't discuss, review the permissions.");
+  if (!pronote.authorizations.canDiscussWithTeachers) throw new Error("This account can't discuss with teachers, review the permissions.");
+
+  // Get an overview of available discussions.
+  const discussionsOverview = await pronote.getDiscussionsOverview();
+  // Select the first discussion available.
+  const firstDiscussion = discussionsOverview.discussions[0];
+  console.info("Opening discussion:", firstDiscussion.subject);
+  console.log("Containing", firstDiscussion.numberOfDrafts, "draft(s)...");
+  console.log("Containing", firstDiscussion.numberOfMessages - firstDiscussion.numberOfDrafts, "message(s)...");
+
+  // Fetch the messages overview from the discussion.
+  // You need to fetch the overview in order to send a message.
+  const messagesOverview = await firstDiscussion.fetchMessagesOverview();
+
+  // Send a message to the discussion.
+  // Using this method directly on the overview will create a draft replying to the current latest message.
+  await messagesOverview.draftMessage("Hello, I'm replying to the latest message using Pawnote (but as a draft) !");
+
+  // But you can also select a message to reply to.
+  await messagesOverview.messages[0].draftReply("Hello, I'm replying to the first message using Pawnote (but as a draft) !");
+  // Or do the following : await messagesOverview.draftMessage("...", messagesOverview.messages[0].id);
+
+  for (const draft of messagesOverview.savedDrafts) {
+    console.log("Draft:", draft.possessionID);
+    console.log("Draft:", draft.content);
+  }
+})();
+

--- a/examples/discussions/send-all-draft.ts
+++ b/examples/discussions/send-all-draft.ts
@@ -1,0 +1,34 @@
+import { authenticatePronoteCredentials, PronoteApiAccountId } from "../../src";
+
+(async () => {
+  const pronote = await authenticatePronoteCredentials("https://pronote-vm.dev/pronote", {
+    accountTypeID: PronoteApiAccountId.Student,
+    username: "lisa.boulanger", // using my VM credentials here because the demo instance doesn't have any messages.
+    password: "12345678",
+
+    // Because this is just an example, don't forget to change this.
+    deviceUUID: "my-device-uuid"
+  });
+
+  // You can do those checks manually, they're also done internally and will throw an error if the account can't do this.
+  if (!pronote.authorizations.canDiscuss) throw new Error("This account can't discuss, review the permissions.");
+  if (!pronote.authorizations.canDiscussWithTeachers) throw new Error("This account can't discuss with teachers, review the permissions.");
+
+  // Get an overview of available discussions.
+  const discussionsOverview = await pronote.getDiscussionsOverview();
+  // Select the first discussion available.
+  const firstDiscussion = discussionsOverview.discussions[0];
+  console.info("Opening discussion:", firstDiscussion.subject);
+  console.log("Containing", firstDiscussion.numberOfDrafts, "draft(s)...");
+  console.log("Containing", firstDiscussion.numberOfMessages - firstDiscussion.numberOfDrafts, "message(s)...");
+
+  // Fetch the messages overview from the discussion.
+  // You need to fetch the overview in order to send a message.
+  const messagesOverview = await firstDiscussion.fetchMessagesOverview();
+
+  for (const draft of messagesOverview.savedDrafts) {
+    await draft.send();
+    console.log("Draft sent:", draft.possessionID);
+  }
+})();
+

--- a/examples/discussions/update-draft.ts
+++ b/examples/discussions/update-draft.ts
@@ -1,0 +1,35 @@
+import { authenticatePronoteCredentials, PronoteApiAccountId } from "../../src";
+
+(async () => {
+  const pronote = await authenticatePronoteCredentials("https://pronote-vm.dev/pronote", {
+    accountTypeID: PronoteApiAccountId.Student,
+    username: "lisa.boulanger", // using my VM credentials here because the demo instance doesn't have any messages.
+    password: "12345678",
+
+    // Because this is just an example, don't forget to change this.
+    deviceUUID: "my-device-uuid"
+  });
+
+  // You can do those checks manually, they're also done internally and will throw an error if the account can't do this.
+  if (!pronote.authorizations.canDiscuss) throw new Error("This account can't discuss, review the permissions.");
+  if (!pronote.authorizations.canDiscussWithTeachers) throw new Error("This account can't discuss with teachers, review the permissions.");
+
+  // Get an overview of available discussions.
+  const discussionsOverview = await pronote.getDiscussionsOverview();
+  // Select the first discussion available.
+  const firstDiscussion = discussionsOverview.discussions[0];
+  console.info("Opening discussion:", firstDiscussion.subject);
+  console.log("Containing", firstDiscussion.numberOfDrafts, "draft(s)...");
+  console.log("Containing", firstDiscussion.numberOfMessages - firstDiscussion.numberOfDrafts, "message(s)...");
+
+  // Fetch the messages overview from the discussion.
+  // You need to fetch the overview in order to send a message.
+  const messagesOverview = await firstDiscussion.fetchMessagesOverview();
+
+  for (const draft of messagesOverview.savedDrafts) {
+    console.log("Draft:", draft.possessionID);
+    draft.content = "This is a new content for the draft." + Date.now() + draft.content;
+    await draft.save();
+  }
+})();
+

--- a/src/api/user/createDiscussionMessage/types.ts
+++ b/src/api/user/createDiscussionMessage/types.ts
@@ -14,7 +14,7 @@ export interface PronoteApiUserCreateDiscussionMessage {
     donnees: {
       bouton: {
         N: 0
-        G: number
+        G: PronoteApiMessagesButtonType
       }
 
       genreDiscussion: 0

--- a/src/api/user/discussionCommand/index.ts
+++ b/src/api/user/discussionCommand/index.ts
@@ -1,16 +1,69 @@
+import { PronoteApiDiscussionCommandType } from "~/constants/discussion";
 import type { ApiUserDiscussionCommand, PronoteApiUserDiscussionCommand } from "./types";
 
 import { PronoteApiFunctions } from "~/constants/functions";
 import { PronoteApiOnglets } from "~/constants/onglets";
 import { createPronoteAPICall } from "~/pronote/requestAPI";
 import { makeApiHandler } from "~/utils/api";
+import { PronoteApiStateType } from "~/constants/states";
 
 export const callApiUserDiscussionCommand = makeApiHandler<ApiUserDiscussionCommand>(async (fetcher, input) => {
-  const payload = input.session.writePronoteFunctionPayload<PronoteApiUserDiscussionCommand["request"]>({
-    donnees: {
+  let data: PronoteApiUserDiscussionCommand["request"]["donnees"];
+
+  if (input.command === PronoteApiDiscussionCommandType.brouillon) {
+    data = {
+      commande: input.command,
+      brouillon: typeof input.id === "number" ? {
+        E:  PronoteApiStateType.CREATION,
+        N: input.id
+      } : {
+        E: PronoteApiStateType.MODIFICATION,
+        N: input.id
+      },
+
+      contenu: input.content,
+
+      messagePourReponse: {
+        G: 0,
+        N: input.replyMessageID
+      },
+
+      listeDestinataires: [],
+      listeFichiers: [],
+      objet: ""
+    };
+  }
+  else if (input.command === "") {
+    data = {
+      commande: input.command,
+      bouton: {
+        N: 0,
+        G: input.button
+      },
+
+      brouillon: {
+        N: input.id
+      },
+
+      contenu: input.content,
+      listeDestinataires: [],
+      listeFichiers: [],
+
+      messagePourReponse: {
+        G: 0,
+        N: input.replyMessageID
+      }
+    };
+  }
+  else {
+    data = {
       commande: input.command,
       listePossessionsMessages: input.possessions
-    },
+    };
+  }
+
+  const payload = input.session.writePronoteFunctionPayload<PronoteApiUserDiscussionCommand["request"]>({
+    donnees: data,
 
     _Signature_: {
       onglet: PronoteApiOnglets.Discussions

--- a/src/api/user/discussionCommand/types.ts
+++ b/src/api/user/discussionCommand/types.ts
@@ -1,6 +1,8 @@
 import { PronoteApiDiscussionCommandType } from "~/constants/discussion";
 import type { PronoteApiFunctions } from "~/constants/functions";
+import { PronoteApiMessagesButtonType } from "~/constants/messages";
 import type { PronoteApiOnglets } from "~/constants/onglets";
+import { PronoteApiStateType } from "~/constants/states";
 import type { Session } from "~/session";
 
 export interface PronoteApiUserDiscussionCommand {
@@ -10,8 +12,44 @@ export interface PronoteApiUserDiscussionCommand {
     }
 
     donnees: {
-      commande: PronoteApiDiscussionCommandType
+      commande: PronoteApiDiscussionCommandType.corbeille | PronoteApiDiscussionCommandType.suppression | PronoteApiDiscussionCommandType.restauration
       listePossessionsMessages: Array<{ N: string }>
+    } | {
+      commande: PronoteApiDiscussionCommandType.brouillon
+
+      brouillon: {
+        N: number
+        E: PronoteApiStateType.CREATION
+      } | {
+        N: string
+        E: PronoteApiStateType.MODIFICATION
+      }
+
+      messagePourReponse: {
+        N: string
+        G: 0
+      }
+
+      objet: ""
+      contenu: string
+
+      // TODO: For other account types, maybe ?
+      listeDestinataires: never[]
+      listeFichiers: never[]
+    } | {
+      commande: ""
+      bouton: {
+        N: 0
+        G: PronoteApiMessagesButtonType
+      }
+      brouillon: { N: string }
+      messagePourReponse: {
+        N: string
+        G: 0
+      }
+      contenu: string
+      listeDestinataires: never[]
+      listeFichiers: never[]
     }
   }
 
@@ -25,9 +63,31 @@ export interface PronoteApiUserDiscussionCommand {
 export interface ApiUserDiscussionCommand {
   input: {
     session: Session
-    command: PronoteApiDiscussionCommandType
-    possessions: Array<{ N: string }>
-  }
+  } & ApiUserDiscussionAvailableCommands
 
   output: PronoteApiUserDiscussionCommand["response"]
 }
+
+export type ApiUserDiscussionAvailableCommands = (
+  | {
+    command: PronoteApiDiscussionCommandType.corbeille | PronoteApiDiscussionCommandType.suppression | PronoteApiDiscussionCommandType.restauration
+    possessions: Array<{ N: string, E?: PronoteApiStateType.MODIFICATION }>
+  }
+  | {
+    command: PronoteApiDiscussionCommandType.brouillon
+    /**
+     * - Give `string` to be in edition mode.
+     * - Give `number` to be in creation mode.
+     */
+    id: string | number
+    replyMessageID: string
+    content: string
+  }
+  | {
+    command: "" // empty when sending
+    button: PronoteApiMessagesButtonType
+    id: string
+    replyMessageID: string
+    content: string
+  }
+);

--- a/src/api/user/discussions/types.ts
+++ b/src/api/user/discussions/types.ts
@@ -85,6 +85,8 @@ export interface PronoteApiUserDiscussions {
         indicePere?: number
         nbPublic?: number
         initiateur?: string
+
+        nbBrouillons?: number
       }>>
 
       strSuperAdministrateurs: string

--- a/src/api/user/messages/types.ts
+++ b/src/api/user/messages/types.ts
@@ -32,6 +32,12 @@ export interface PronoteApiUserMessages {
         L: string
       }>>
 
+      brouillon?: PronoteValue<24, {
+        N: string
+        contenu: PronoteValue<21, string>
+        estHTML: boolean
+      }>
+
       /** Is defined only when `marquerCommeLu` is set to `true` in the payload. */
       nbMarquerLu?: number
       nbPossessionsMessage: number

--- a/src/client/Pronote.ts
+++ b/src/client/Pronote.ts
@@ -66,8 +66,8 @@ import { PronoteApiDomainFrequencyType, PronoteApiMaxDomainCycle } from "~/const
 import { parseSelection } from "~/pronote/select";
 import { TimetableOverview } from "~/parser/timetable";
 import { callApiUserDiscussionCommand } from "~/api/user/discussionCommand";
-import { PronoteApiDiscussionCommandType } from "~/constants/discussion";
 import { ARDPartner } from "~/parser/partners/ard";
+import { ApiUserDiscussionAvailableCommands } from "~/api/user/discussionCommand/types";
 
 export default class Pronote {
   /**
@@ -496,16 +496,13 @@ export default class Pronote {
     });
   }
 
-  public async postDiscussionCommand (discussion: StudentDiscussion, command: PronoteApiDiscussionCommandType): Promise<void> {
+  public async postDiscussionCommand (payload: ApiUserDiscussionAvailableCommands): Promise<void> {
     await this.queue.push(async () => {
       await callApiUserDiscussionCommand(this.fetcher, {
-        possessions: discussion.possessions,
         session: this.session,
-        command: command
+        ...payload
       });
     });
-
-    await discussion.refetch();
   }
 
   /**

--- a/src/constants/discussion.ts
+++ b/src/constants/discussion.ts
@@ -30,6 +30,7 @@ export enum PronoteApiDiscussionCommandType {
   corbeille = "corbeille",
   restauration = "restauration",
   suppression = "suppression",
+  brouillon = "brouillon",
   plus = "plus",
   purger = "purger",
   discussionEnFenetre = "discussionEnFenetre",

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -20,13 +20,25 @@ export type PronoteApiMessageContent = (
     estHTML: false
   }
   | {
-    contenu: PronoteValue<number, string>;
+    contenu: PronoteValue<21, string>;
     estHTML: true
   }
 );
 
+export type PronoteApiDraftMessage = PronoteApiMessageContent & {
+  possessionMessage: PronoteValue<24, {
+    N: string
+  }>
+
+  messageSource: PronoteValue<24, {
+    N: string
+  }>
+};
+
 type PronoteApiMessage = PronoteApiMessageContent & {
   N: string
+
+  brouillon?: boolean
 
   /**
    * When the message is a reply to another one,

--- a/src/parser/discussion.ts
+++ b/src/parser/discussion.ts
@@ -194,18 +194,35 @@ export class StudentDiscussion {
 
   public async moveToTrash (): Promise<void> {
     this.#assertNotDeleted();
-    await this.#client.postDiscussionCommand(this, PronoteApiDiscussionCommandType.corbeille);
+
+    await this.#client.postDiscussionCommand({
+      command: PronoteApiDiscussionCommandType.corbeille,
+      possessions: this.possessions
+    });
+
+    await this.refetch();
   }
 
   public async restoreFromTrash (): Promise<void> {
     this.#assertNotDeleted();
-    await this.#client.postDiscussionCommand(this, PronoteApiDiscussionCommandType.restauration);
+
+    await this.#client.postDiscussionCommand({
+      command: PronoteApiDiscussionCommandType.restauration,
+      possessions: this.possessions
+    });
+
+    await this.refetch();
   }
 
   public async deletePermanently (): Promise<void> {
     this.#assertNotDeleted();
 
-    await this.#client.postDiscussionCommand(this, PronoteApiDiscussionCommandType.suppression);
+    await this.#client.postDiscussionCommand({
+      command: PronoteApiDiscussionCommandType.suppression,
+      possessions: this.possessions
+    });
+
+    await this.refetch();
     this.#permanentlyDeleted = true;
   }
 
@@ -223,6 +240,10 @@ export class StudentDiscussion {
    */
   public get possessions (): PronoteApiMessagesPossessionsList {
     return this.#readData().listePossessionsMessages.V;
+  }
+
+  public get numberOfDrafts (): number {
+    return this.#readData().nbBrouillons ?? 0;
   }
 
   /**


### PR DESCRIPTION
- Support to read `savedDrafts` on MessageOverview
- Support to create a draft from the overview or on any message
- Add methods to delete, save and send a draft