### PR TITLE
feat(client): `generateGradesReportPDF`

### DIFF
--- a/examples/grades-report.ts
+++ b/examples/grades-report.ts
@@ -1,0 +1,21 @@
+import { authenticatePronoteCredentials, PronoteApiAccountId, PronoteApiGradeType } from "../src";
+
+(async () => {
+  const pronote = await authenticatePronoteCredentials("https://pronote-vm.dev/pronote", {
+    accountTypeID: PronoteApiAccountId.Student,
+    username: "lisa.boulanger", // using my VM credentials here because the demo instance doesn't have any messages.
+    password: "12345678",
+
+    // Because this is just an example, don't forget to change this.
+    deviceUUID: "my-device-uuid"
+  });
+
+  const periods = pronote.readPeriodsForGradesReport();
+  const period = periods.find((period) => period.name === "Semestre 1");
+  if (!period) throw new Error("Period not found.");
+
+  console.log("Fetching for period:", period.name, "\n");
+  const reportURL = await pronote.generateGradesReportPDF(period);
+
+  console.log("Report URL:", reportURL);
+})();

--- a/src/api/login/informations/types.ts
+++ b/src/api/login/informations/types.ts
@@ -4,6 +4,7 @@ import type { Session } from "~/session";
 import type { PronoteApiDomainFrequencyType } from "~/constants/domain";
 import type { PronoteValue } from "~/api/type";
 import type { PronoteApiHTTPType } from "~/constants/http";
+import type { PronoteApiID } from "~/constants/id";
 
 export interface PronoteApiLoginInformations {
   request: {
@@ -337,7 +338,7 @@ export interface PronoteApiLoginInformations {
           /** Name of the period. */
           L: string
           /** ID of the period. */
-          N: string
+          N: PronoteApiID<112> | "0"
           G: number
 
           periodeNotation: number

--- a/src/api/user/generatePDF/index.ts
+++ b/src/api/user/generatePDF/index.ts
@@ -1,0 +1,47 @@
+import { PronoteApiOnglets } from "~/constants/onglets";
+import type { ApiUserGeneratePDF, PronoteApiUserGeneratePDF } from "./types";
+import { makeApiHandler } from "~/utils/api";
+import { createPronoteAPICall } from "~/pronote/requestAPI";
+import { PronoteApiFunctions } from "~/constants/functions";
+
+export const callApiUserGeneratePDF = makeApiHandler<ApiUserGeneratePDF>(async (fetcher, input) => {
+  // PRONOTE does not allow generating PDF for dynamically generated periods.
+  if (input.period.id === "0") throw new Error("Cannot generate PDF for period with ID 0.");
+
+  const request_payload = input.session.writePronoteFunctionPayload<PronoteApiUserGeneratePDF["request"]>({
+    donnees: {
+      avecCodeCompetences: false,
+      genreGenerationPDF: 2,
+
+      options: { // defaults from PRONOTE
+        adapterHauteurService: false,
+        desEleves: false,
+        gererRectoVerso: false,
+        hauteurServiceMax: 15,
+        hauteurServiceMin: 10,
+        piedMonobloc: true,
+        portrait: true,
+        taillePolice: 6.5,
+        taillePoliceMin: 5,
+        taillePolicePied: 6.5,
+        taillePolicePiedMin: 5
+      },
+
+      periode: {
+        N: input.period.id,
+        G: input.period.genre,
+        L: input.period.name
+      }
+    },
+
+    _Signature_: { onglet: PronoteApiOnglets.GradesReport }
+  });
+  const response = await createPronoteAPICall(fetcher, PronoteApiFunctions.GeneratePDF, {
+    session_instance: input.session.instance,
+    payload: request_payload
+  });
+
+
+  const received = input.session.readPronoteFunctionPayload<PronoteApiUserGeneratePDF["response"]>(response.payload);
+  return { url: received.donnees.url.V };
+});

--- a/src/api/user/generatePDF/types.ts
+++ b/src/api/user/generatePDF/types.ts
@@ -1,0 +1,59 @@
+import type { PronoteValue } from "~/api/type";
+import type { PronoteApiFunctions } from "~/constants/functions";
+import type { PronoteApiHTTPType } from "~/constants/http";
+import type { PronoteApiID } from "~/constants/id";
+import type { PronoteApiOnglets } from "~/constants/onglets";
+import type { Period } from "~/parser/period";
+import type { Session } from "~/session";
+
+export interface PronoteApiUserGeneratePDF {
+  request: {
+    donnees: {
+      avecCodeCompetences: boolean
+      genreGenerationPDF: 2
+      options: {
+        adapterHauteurService: boolean
+        desEleves: boolean
+        gererRectoVerso: boolean
+        hauteurServiceMax: number
+        hauteurServiceMin: number
+        piedMonobloc: boolean
+        portrait: boolean
+        taillePolice: number
+        taillePoliceMin: number
+        taillePolicePied: number
+        taillePolicePiedMin: number
+      }
+      periode: {
+        G: number
+        L: string
+        N: PronoteApiID<112>
+      }
+    }
+
+    _Signature_: {
+      onglet: PronoteApiOnglets.GradesReport
+    }
+  }
+
+  response: {
+    donnees: {
+      /** Path relative to root URL. */
+      url: PronoteValue<PronoteApiHTTPType.ChaineBrute, string>
+    }
+
+    nom: PronoteApiFunctions.GeneratePDF
+  }
+}
+
+export interface ApiUserGeneratePDF {
+  input: {
+    session: Session
+    period: Period
+  }
+
+  output: {
+    /** Path relative to root URL. */
+    url: string
+  }
+}

--- a/src/constants/functions.ts
+++ b/src/constants/functions.ts
@@ -22,5 +22,6 @@ export enum PronoteApiFunctions {
   CreateDiscussionRecipients = "ListeRessourcesPourCommunication",
   CreateMessage = "SaisieMessage",
   HomePage = "PageAccueil",
-  PartnerURL = "SaisieURLPartenaire"
+  PartnerURL = "SaisieURLPartenaire",
+  GeneratePDF = "GenerationPDF"
 }

--- a/src/constants/onglets.ts
+++ b/src/constants/onglets.ts
@@ -8,5 +8,6 @@ export enum PronoteApiOnglets {
   Presence = 7,
   News = 8,
   Attendance = 19,
-  Discussions = 131
+  Discussions = 131,
+  GradesReport = 13
 }

--- a/src/parser/period.ts
+++ b/src/parser/period.ts
@@ -1,5 +1,6 @@
 import type Pronote from "~/client/Pronote";
 import type { PronoteApiLoginInformations, PronoteApiUserData } from "~/api";
+import type { PronoteApiID } from "~/constants/id";
 
 import { readPronoteApiDate } from "~/pronote/dates";
 
@@ -25,7 +26,7 @@ export class OngletPeriod {
 }
 
 export class Period {
-  public id: string;
+  public id: PronoteApiID<112> | "0";
   public name: string;
   public genre: number;
 


### PR DESCRIPTION
- Allows to get the grades report PDF URL for a given period.
- Add getters for available periods for grades report.

```typescript
const pronote = await authenticatePronoteCredentials("https://pronote-vm.dev/pronote", {
  accountTypeID: PronoteApiAccountId.Student,
  username: "lisa.boulanger",
  password: "12345678",

  // Because this is just an example, don't forget to change this.
  deviceUUID: "my-device-uuid"
});

const periods = pronote.readPeriodsForGradesReport();
const period = periods.find((period) => period.name === "Semestre 1");
if (!period) throw new Error("Period not found.");

console.log("Fetching for period:", period.name, "\n");
const reportURL = await pronote.generateGradesReportPDF(period);

console.log("Report URL:", reportURL);
```

![image](https://github.com/LiterateInk/Pawnote/assets/59152884/c2804d15-314c-4510-a68f-cfe3e2580c83)
