### PR TITLE
fix: Allow headers to be retreived without the Headers object globally set

### DIFF
--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -11,7 +11,6 @@ export const retrieveResponseCookies = (headers: Record<string, string> | Header
 };
 
 export const getHeaderFromFetcherResponse = (headers: Record<string, string> | Headers, item: string): string | null => {
-  if (Headers == undefined) return headers.get(item);
-  
-  return headers instanceof Headers ? headers.get(item) : headers[item];
+  if (typeof headers.get === "function") return headers.get(item);
+  return headers[item];
 };

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -11,5 +11,7 @@ export const retrieveResponseCookies = (headers: Record<string, string> | Header
 };
 
 export const getHeaderFromFetcherResponse = (headers: Record<string, string> | Headers, item: string): string | null => {
+  if (Headers == undefined) return headers.get(item);
+  
   return headers instanceof Headers ? headers.get(item) : headers[item];
 };

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -11,6 +11,5 @@ export const retrieveResponseCookies = (headers: Record<string, string> | Header
 };
 
 export const getHeaderFromFetcherResponse = (headers: Record<string, string> | Headers, item: string): string | null => {
-  if (typeof headers.get === "function") return headers.get(item);
-  return headers[item];
+  return (typeof headers.get === "function") ? headers.get(item) : headers[item];
 };


### PR DESCRIPTION
# Description

When the global Headers object doesn't exist, they can't be retreived, causing a Pawnote crash.
This fix allows it to return the Headers item (assuming it exists) even without the instanciation.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Authenticate using Pawnote in a header-less environment
- [x] Authenticate using Pawnote normally

**Test Configuration**:

Desktop (please complete the following information) :
- OS: macOS 14
- Node 20.13.1

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

