### PR TITLE
fix(geolocation): Use lowercase URLs to avoid conflicts

### DIFF
--- a/src/api/geolocation/index.ts
+++ b/src/api/geolocation/index.ts
@@ -36,6 +36,7 @@ export const callApiGeolocation = makeApiHandler<ApiGeolocation>(async (fetcher,
     name: decode(result.nomEtab) // Use UTF8 instead of HTML entities encoding.
       .replace("COLLEGE", "COLLÈGE")
       .replace("LYCEE", "LYCÉE")
+      .toLowerCase() // Replaces `/ProNote` with `/pronote` to avoid session conflicts
       .trim(), // Prevent some `\r\n` at the end of some strings.
 
     latitude: parseFloat(result.lat),


### PR DESCRIPTION
# Description

Using Geolocation API, Pronote may use links ending with `/ProNote` instead of `/pronote`
When your code relies on these URLs to apply attributes, it might be the cause of your issue :
- When using the cookie injection method to login using ENT, the URL difference between the geolocation API and Pronote redirection might break the authentification flow

> This change allows the URL to be directly sent in lowercase, to avoid such issues.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

