### PR TITLE
addBeforeRequest handler

### DIFF
--- a/src/core/request-function.ts
+++ b/src/core/request-function.ts
@@ -37,6 +37,11 @@ export class RequestFN {
     const order = this.generateOrder();
     const url = new URL(`${this.session.information.url}/appelfonction/${this.session.information.accountKind}/${this.session.information.id}/${order}`);
 
+    if (this.session.beforeRequest) {
+      const newdata = this.session.beforeRequest(this.data);
+      if (newdata) this.data = newdata;
+    }
+
     if (!this.session.information.skipCompression) {
       this.compress();
     }

--- a/src/models/session-handle.ts
+++ b/src/models/session-handle.ts
@@ -14,6 +14,8 @@ export type SessionHandle = {
   instance: InstanceParameters
   user: UserParameters
 
+  beforeRequest: undefined | ((data: any) => any)
+
   /**
    * Can be updated with the `pronote.use(number | UserResource)` method.
    * @default user.resources[0] // first resource from the user


### PR DESCRIPTION
# Description

Add a `beforeRequest` handler to session that gets called before send data to pronote (and also before encrypt / compress).  
Allows you to log or modify request before sending it.

Choice I made that can be discussed:
 - returning nullish doesn't remove data (so `session.beforeRequest = (data) => { console.log(data) }` works)
 - i've made it a sync function, not async

This allows me to have a parent api working for my use case without modifying the lib : 
```js
session.beforeRequest = (data) => {
  if (session?.user && data?._Signature_) {
    if (session.information.accountKind === 7 /* AccountKind.PARENT */) {
      const kid = session.userResource;
      if (kid) {
        data._Signature_.membre = {
          N: kid.id,
          G: kid.kind,
        };
      }
    }
  }
};
```

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

