### PR TITLE
feat(ressources): add the `categoryText` attribute

### DIFF
--- a/src/decoders/resource-content.ts
+++ b/src/decoders/resource-content.ts
@@ -8,6 +8,7 @@ export const decodeResourceContent = (content: any, session: SessionHandle): Res
     title: content.L,
     description: content.descriptif.V,
     category: content.categorie.V.G,
+    categoryText: content.category.V.L,
     files: content.ListePieceJointe.V.map((attachment: any) => decodeAttachment(attachment, session)),
     themes: content.ListeThemes.V.map((theme: any) => decodeAssignmentTheme(theme)),
     // TODO: Investigate to see what is contained here when not `-1`.

--- a/src/models/resource-content.ts
+++ b/src/models/resource-content.ts
@@ -16,6 +16,7 @@ export type ResourceContent = Readonly<{
   description?: string;
 
   category: ResourceContentCategory;
+  categoryText?: string;
   files: Attachment[];
   /** Themes associated with the lesson. */
   themes: AssignmentTheme[];


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

This pull request permit to obtain the text given when a ressource have `ResourceContentCategory` set to `0`.
For example:
<details><summary>Data</summary>

```json
{
    "donnees": {
        "ListeCahierDeTextes": {
            "_T": 24,
            "V": [
                {
                    "N": "18#VCRZcloK8YAdKRbCfT-5fKu6MlTytvXIR6lg1yarT3g",
                    "cours": {... },
                    "verrouille": false,
                    "listeGroupes": {...},
                    "Matiere": {...},
                    "CouleurFond": "#2338BB",
                    "listeProfesseurs": {...},
                    "Date": {...},
                    "DateFin": {...},
                    "listeContenus": {
                        "_T": 24,
                        "V": [
                            {
                                "L": "Connaître les caractéristiques génériques des différents documents étudiés",
                                "N": "29#rRGMPPdztxlL5hKRwVCyJS3JfKhRlvJ_8vTV84kBCZc",
                                "descriptif": {
                                    "_T": 21,
                                    "V": "Connaître les caractéristiques génériques des différents documents étudiés (articles de presse d'information et scientifique, essais, textes documentaires, schémas, graphiques, tableaux, images fixes et mobiles, etc.)"
                                },
                                "categorie": {
                                    "_T": 24,
                                    "V": {
                                        "L": "Travaux dirigés",
                                        "N": "19#MBuPxGNflpVrf8LCH9V3IiPstBBUN6dpm0j2G5PqyxQ",
                                        "G": 5
                                    }
                                },
                                "ListeThemes": {...},
                                "libelleCBTheme": "Uniquement les thèmes associés aux matières du contenu",
                                "parcoursEducatif": -1,
                                "ListePieceJointe": {
                                    "_T": 24,
                                    "V": [
                                        {
                                            "L": "Logigramme_old.png",
                                            "N": "39#XAt0kUdASxATqdUCjp1HwuiBufLU8C1QtKiMqKYoX60",
                                            "G": 1,
                                            "estUnLienInterne": false,
                                            "avecMiniaturePossible": true
                                        }
                                    ]
                                },
                                "training": {...}
                            },
                            {
                                "L": "Un autre contenu de cours (ça n'arrive jamais en faite)",
                                "N": "29#TX7DlDUH_yUVTXqlRQlbgwv8pG4h4T7I-5VMRLwObtU",
                                "descriptif": {
                                    "_T": 21,
                                    "V": "<div style=\"font-family: Arial; font-size: 13px;\">Flemme d'écrire trop wesh, on va chez quick wesh, j'ai envie d'un burger !</div>"
                                },
                                "categorie": {
                                    "_T": 24,
                                    "V": {
                                        "L": "Cours & correction",
                                        "N": "19#XahBdyb6QAcatpvKI4qZAqLYK11LMwgL_k_ZuxI4cuo",
                                        "G": 0
                                    }
                                },
                                "ListeThemes": {...},
                                "libelleCBTheme": "Uniquement les thèmes associés aux matières du contenu",
                                "parcoursEducatif": -1,
                                "ListePieceJointe": {...},
                                "training": {...}
                            }
                        ]
                    },
                    "listeElementsProgrammeCDT": {...}
                }
            ]
        },
        "ListeRessourcesPedagogiques": {...},
        "ListeRessourcesNumeriques": {...}
    },
    "nom": "PageCahierDeTexte"
}
```

</details> 

The second exemple with title `Un autre contenu de cours (ça n'arrive jamais en faite)` have a `ResourceContentCategory` set to 0. But we have a name `Cours & correction` which is gave for describe the ressource category.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

