### PR TITLE
New grades response

### DIFF
--- a/examples/grades-overview.ts
+++ b/examples/grades-overview.ts
@@ -86,9 +86,9 @@ void async function main () {
   overview.subjectsAverages.forEach((average) => {
     console.log("->", average.subject.name);
     console.log("Student:", average.student);
-    console.log("Class:", average.class_average);
-    console.log("Max:", average.max);
-    console.log("Min:", average.min);
+    console.log("Class:", average.class_average ?? "Unspecified");
+    console.log("Max:", average.max ?? "Unspecified");
+    console.log("Min:", average.min ?? "Unspecified");
 
     // Break line for next entry.
     console.log();

--- a/src/decoders/subject-averages.ts
+++ b/src/decoders/subject-averages.ts
@@ -7,9 +7,9 @@ export const decodeSubjectAverages = (average: any): SubjectAverages => {
     student: average.moyEleve && decodeGradeValue(average.moyEleve.V),
     outOf: average.baremeMoyEleve && decodeGradeValue(average.baremeMoyEleve.V),
     defaultOutOf: average.baremeMoyEleveParDefaut && decodeGradeValue(average.baremeMoyEleveParDefaut.V),
-    class_average: decodeGradeValue(average.moyClasse.V),
-    min: decodeGradeValue(average.moyMin.V),
-    max: decodeGradeValue(average.moyMax.V),
+    class_average: average.moyClasse && decodeGradeValue(average.moyClasse.V),
+    min: average.moyMin && decodeGradeValue(average.moyMin.V),
+    max: average.moyMax && decodeGradeValue(average.moyMax.V),
     subject: decodeSubject(average),
     backgroundColor: average.couleur
   };

--- a/src/models/subject-averages.ts
+++ b/src/models/subject-averages.ts
@@ -5,11 +5,11 @@ export type SubjectAverages = Readonly<{
   /** students average in the subject */
   student?: GradeValue;
   /** classes average in the subject */
-  class_average: GradeValue;
+  class_average?: GradeValue;
   /** highest average in the class */
-  max: GradeValue;
+  max?: GradeValue;
   /** lowest average in the class */
-  min: GradeValue;
+  min?: GradeValue;
   /** maximum amount of points */
   outOf?: GradeValue;
   /** the default maximum amount of points */


### PR DESCRIPTION
# Description

Since the version 2024.8.3 of the Pronote server, `moyClasse`, `moyMin` and `moyMax` are only send if service details are enabled, before they were sent whether it was activated or not, they were just hidden from the UI.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Use `examples/grades-overview.ts` with different configurations

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

